### PR TITLE
Customize the tiddler field to display in the timeline

### DIFF
--- a/plugins/timeline/tiddlers/usage.tid
+++ b/plugins/timeline/tiddlers/usage.tid
@@ -47,7 +47,7 @@ Each matching tiddler is shown on the timeline using its specified start date an
 
 !! Relevant tiddler fields
 |!Field|!Interpretation|
-| `caption` |Used to represent the tiddler instead of the `title`.|
+| `caption` |Used to represent the tiddler instead of the `title` (unless overridden by `captionField`).|
 | `description` |Used instead of `caption` or `title` to render description text when mouse hovers over the item.|
 | `icon` |Link to a image tiddler that will be used as the item's icon.|
 | `color` |Used to render the corresponding item or group on the timeline.|
@@ -59,6 +59,7 @@ All attributes are optional.
 
 |!Attribute|!Description|!Default value|! |
 | `filter` |The [[TiddlerFilter|http://tiddlywiki.com/#Filters]] used to generate the list of tiddlers to display.|`!is[system]`|<<tryit filter "[all[tiddlers]tag[Group A]]">>|
+| `captionField` |The field on each tiddler that gets displayed in the timeline.|`caption`||
 | `startDateField` |A field on each tiddler that defines the start date of a tiddler in the timeline.|`created`|<<tryit startDateField modified>>|
 | `endDateField` |A field on each tiddler that defines the end date of a tiddler in the timeline.|//undefined//|<<tryit endDateField created>>|
 | `format` |The format for parsing the dates, using the moment.js [[Parse string+format|http://momentjs.com/docs/#/parsing/string-format/]]. If unset, uses [[TW5 date format|http://tiddlywiki.com/#DateFormat]].|//undefined//||

--- a/plugins/timeline/widget.timeline.js
+++ b/plugins/timeline/widget.timeline.js
@@ -95,6 +95,7 @@ module-type: widget
   TimelineWidget.prototype.execute = function() {
     var attrParseWorked = utils.parseWidgetAttributes(this,{
            filter: { type: "string", defaultValue: "[!is[system]]"},
+           captionField: { type: "string", defaultValue: "caption"},
            groupField: { type: "string", defaultValue: undefined},
            startDateField: { type: "string", defaultValue: "created"},
            endDateField:  { type: "string", defaultValue: undefined},
@@ -141,6 +142,7 @@ module-type: widget
   TimelineWidget.prototype.refresh = function(changedTiddlers) {
     var changedAttributes = this.computeAttributes();
     if(changedAttributes.filter
+	|| changedAttributes.captionField
     || changedAttributes.startDateField
     || changedAttributes.endDateField
     || changedAttributes.groupField
@@ -473,7 +475,7 @@ module-type: widget
         var tiddlerStartDate = theTiddler.getFieldString(self.startDateField);
         var startDate = dateFieldToDate(tiddlerStartDate, self.format);
         if (!isNaN(startDate)) {
-          var caption = theTiddler.fields.caption || tiddlerName,
+          var caption = theTiddler.getFieldString(self.captionField) || tiddlerName,
               description = theTiddler.fields.description || caption,
               color = theTiddler.fields.color || false,
               style = "border-color: " + color + ";" || "",


### PR DESCRIPTION
This PR adds the attribute `captionField` to `<$visjstimeline>`. It defines the field to display for each tiddler when rendering the timeline.
To match the current behavior, it defaults to `caption`.